### PR TITLE
Update macerator recipe for new IC2 API

### DIFF
--- a/src/powercrystals/netherores/ores/Ores.java
+++ b/src/powercrystals/netherores/ores/Ores.java
@@ -1,7 +1,7 @@
 package powercrystals.netherores.ores;
 
 import cpw.mods.fml.common.Loader;
-import ic2.api.Ic2Recipes;
+import ic2.api.recipe.Recipes;
 import powercrystals.netherores.NetherOresCore;
 import thermalexpansion.api.crafting.CraftingManagers;
 import thermalexpansion.api.item.ItemRegistry;
@@ -157,7 +157,7 @@ public enum Ores
 			ItemStack maceTo = maceStack.copy();
 			maceTo.stackSize = _maceCount;
 
-			Ic2Recipes.addMaceratorRecipe(new ItemStack(NetherOresCore.getOreBlock(_blockIndex), 1, _metadata), maceTo.copy());
+			Recipes.macerator.addRecipe(new ItemStack(NetherOresCore.getOreBlock(_blockIndex), 1, _metadata), maceTo.copy());
 		}
 		
 		if(NetherOresCore.enablePulverizerRecipes.getBoolean(true) && Loader.isModLoaded("ThermalExpansion"))


### PR DESCRIPTION
Fixes "java.lang.NoSuchMethodError: ic2.api.Ic2Recipes.addMaceratorRecipe(Lnet/minecraft/item/ItemStack;Lnet/minecraft/item/ItemStack;)V" crash with IC2 1.115.294.

(note: this PR only changes the code, doesn't update the build process - couldn't get the [ant](https://gist.github.com/agaricusb/5401865)-based build process to work, but I tested with an alternate build system on https://github.com/agaricusb/NetherOres/tree/fix-macerator and the macerator recipes functioned as expected.)
